### PR TITLE
CI config for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: go
+dist: xenial
+
+go:
+  - 1.13.x
+
+notifications:
+  email: false
+
+script:
+  - go build -v
+
+before_deploy:
+  - tar -zcf terraform-provider-vscale.tar.gz terraform-provider-vscale
+
+deploy:
+  provider: releases
+  api_key: ""
+    #secure: ""
+  skip_cleanup: true
+  file: terraform-provider-vscale.tar.gz
+  on:
+    tags: true
+    repo: vozerov/terraform-provider-vscale


### PR DESCRIPTION
This PR implements automatic builds of terraform provider executable. Build will be triggered on tags and placed in "releases" tab.

To make the configuration valid you should fill the secured Github API token variable in the .travis.yml. For detailed instructions, see https://docs.travis-ci.com/user/deployment/releases/ .

Shortly, you should install a travis gem on your machine, login to the Github via travis command and secure the token:

```
$ sudo apt-get install -y ruby ruby-dev libffi-dev
$ sudo gem install travis
$ travis login --pro
We need your GitHub login to identify you.
...
Username: vozerov
Password for vozerov: ***********
Successfully logged in as vozerov!
$ travis encrypt -r vozerov/terraform-provider-vscale --pro "here-goes-the-gh-token"
Please add the following to your .travis.yml file:

  secure: "skipped-due-to-brevity"
```

Please copy the token into CI configuration (.travis.yml), commit and on next tag you will see brand new release on releases page.